### PR TITLE
Refactor audit orchestrator and integrate new rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# Orchestrateur d'audits réseau
+
+## Exécution
+
+```bash
+python3 main.py -u <utilisateur> -p <mot_de_passe>
+```
+
+Options principales :
+
+* `-c` : chemin vers le fichier `main.ini` (par défaut `config/main.ini`).
+* `-i` : fichier contenant les adresses IP (sinon celui défini dans la configuration).
+* `-r` : liste de règles à exécuter (séparées par des virgules). Sans valeur, toutes les règles actives dans la configuration sont lancées.
+* `-w` : nombre de threads.
+
+Les identifiants SNMP peuvent être fournis via la ligne de commande ou des variables d'environnement (`SNMP_USER`, `SNMP_AUTH_KEY`, `SNMP_PRIV_KEY`, `SNMP_AUTH_PROTO`, `SNMP_PRIV_PROTO`).
+
+Les rapports CSV et HTML sont générés dans le dossier `results/` (modifiable dans `main.ini`).
+
+## Structure de configuration
+
+Chaque script Python possède un fichier `.ini` dédié dont le nom est dérivé du nom du script (ex.: `main.py` → `config/main.ini`, `cpu_usage.py` → `config/cpu_usage.ini`).
+
+* `config/main.ini` : paramètres globaux (journalisation, nombre de threads, règles actives...).
+* `config/<nom_regle>.ini` : paramètres spécifiques à chaque règle (commandes CLI, seuils, etc.).
+
+## Ajouter une nouvelle règle d'audit
+
+1. Créer une classe héritant de `BaseAuditRule` dans `audit/rules/`.
+2. Enregistrer la classe dans `audit/rules/__init__.py`.
+3. Créer le fichier `config/<nom_de_la_règle>.ini` contenant les paramètres configurables.
+4. (Optionnel) Ajouter des fonctions de parsing testables et les couvrir avec `tests/test_parsers.py`.
+5. Lancer les tests `python -m unittest`.
+6. Ajouter le nom de la règle à `active_rules` dans `config/main.ini` si elle doit être exécutée par défaut.
+
+## Lancer les tests unitaires
+
+```bash
+python -m unittest discover -s tests
+```
+
+La règle SNMPv3 nécessite `pysnmp`. Si cette dépendance n'est pas installée, elle est automatiquement désactivée pendant les tests.

--- a/audit/config_loader.py
+++ b/audit/config_loader.py
@@ -1,0 +1,31 @@
+"""Chargement des fichiers de configuration .ini."""
+
+from __future__ import annotations
+
+import configparser
+from pathlib import Path
+from typing import Dict
+
+
+def read_ini(path: Path) -> configparser.ConfigParser:
+    parser = configparser.ConfigParser()
+    if not path.exists():
+        return parser
+    parser.read(path, encoding="utf-8")
+    return parser
+
+
+def load_main_config(path: Path) -> Dict[str, str]:
+    parser = read_ini(path)
+    return {key: value for key, value in parser.items("audit")} if parser.has_section("audit") else {}
+
+
+def load_rule_config(rule_name: str, base_dir: Path) -> Dict[str, str]:
+    file_path = base_dir / f"{rule_name}.ini"
+    parser = read_ini(file_path)
+    if parser.has_section(rule_name):
+        return {key: value for key, value in parser.items(rule_name)}
+    if parser.sections():
+        first_section = parser.sections()[0]
+        return {key: value for key, value in parser.items(first_section)}
+    return {}

--- a/audit/rules/__init__.py
+++ b/audit/rules/__init__.py
@@ -1,0 +1,64 @@
+"""Registre des règles d'audit disponibles."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Type
+
+from .base_rules import BaseAuditRule
+from .cpu_usage import CpuUsageRule
+from .fan_health import FanHealthRule
+from .hardware_inventory import HardwareInventoryRule
+from .memory_usage import MemoryUsageRule
+from .power_supply import PowerSupplyRule
+from .snmp_trap_check import SnmpTrapCheckRule
+from .storage_capacity import StorageCapacityRule
+from .sysname import SysnameRule
+from .tacacs import TacacsRule
+from .temperature import TemperatureRule
+from .transceiver_diagnostics import TransceiverDiagnosticsRule
+from .uptime import UptimeRule
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _safe_import_snmp_rule() -> Type[BaseAuditRule] | None:
+    try:
+        from .snmp_v3_test import SnmpV3CheckRule  # type: ignore
+
+        return SnmpV3CheckRule
+    except ModuleNotFoundError as exc:  # pragma: no cover - dépend des dépendances optionnelles
+        LOGGER.warning("Règle SNMPv3 désactivée (module manquant: %s)", exc)
+        return None
+
+
+RULE_CLASSES: tuple[Type[BaseAuditRule], ...] = tuple(
+    filter(
+        None,
+        (
+            SysnameRule,
+            TacacsRule,
+            _safe_import_snmp_rule(),
+            SnmpTrapCheckRule,
+            CpuUsageRule,
+            MemoryUsageRule,
+            FanHealthRule,
+            PowerSupplyRule,
+            TemperatureRule,
+            UptimeRule,
+            HardwareInventoryRule,
+            StorageCapacityRule,
+            TransceiverDiagnosticsRule,
+        ),
+    )
+)  # type: ignore[arg-type]
+
+
+RULE_REGISTRY: Dict[str, Type[BaseAuditRule]] = {rule().name: rule for rule in RULE_CLASSES}
+
+
+def get_rule_class(name: str) -> Type[BaseAuditRule]:
+    try:
+        return RULE_REGISTRY[name]
+    except KeyError as exc:  # pragma: no cover - garde-fou
+        raise KeyError(f"Règle inconnue: {name}") from exc

--- a/audit/rules/base_rules.py
+++ b/audit/rules/base_rules.py
@@ -1,23 +1,22 @@
-#!/usr/bin/env python3
+"""Bases communes aux règles d'audit."""
+
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
+from typing import Any, Dict
+
 
 class BaseAuditRule(ABC):
-    """
-    Classe de base pour une règle d'audit.
+    """Classe de base pour une règle d'audit configurable."""
 
-    Chaque règle doit définir :
-      - name (str)
-      - run(self, info: dict) -> dict
-
-    Le résultat retourné doit être un dict :
-      {"name": <rule_name>, "passed": <bool>, "details": <str>}
-    """
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        self.config: Dict[str, Any] = config or {}
 
     @property
     @abstractmethod
     def name(self) -> str:
-        pass
+        """Nom unique de la règle (utilisé pour l'activation)."""
 
     @abstractmethod
     def run(self, info: dict) -> dict:
-        pass
+        """Exécute la règle et retourne un dictionnaire de résultat."""

--- a/audit/rules/cpu_usage.py
+++ b/audit/rules/cpu_usage.py
@@ -1,0 +1,127 @@
+"""Vérification de la charge CPU."""
+
+from __future__ import annotations
+
+import re
+from statistics import mean
+from typing import List, Tuple
+
+from .base_rules import BaseAuditRule
+from ..utils import disable_paging, normalize_list, run_command_with_paging
+
+
+def parse_cpu_output(output: str) -> Tuple[List[float], List[str]]:
+    """Extrait les valeurs CPU et leurs labels depuis une sortie CLI."""
+
+    values: List[float] = []
+    labels: List[str] = []
+
+    control = re.search(
+        r"Control\s+Plane(.*?)(?=Data\s+Plane|$)", output, re.IGNORECASE | re.DOTALL
+    )
+    if control:
+        block = control.group(1)
+        now_match = re.search(r"CPU\s*Usage:\s*([\d.]+)\s*%", block, re.IGNORECASE)
+        hist_match = re.search(
+            r"ten\s*seconds:\s*([\d.]+)%.*?one\s*minute:\s*([\d.]+)%.*?five\s*minutes:\s*([\d.]+)%",
+            block,
+            re.IGNORECASE | re.DOTALL,
+        )
+        if now_match:
+            values.append(float(now_match.group(1)))
+            labels.append("Now")
+        if hist_match:
+            values.extend([float(hist_match.group(i)) for i in range(1, 4)])
+            labels.extend(["10s", "1m", "5m"])
+        if values:
+            return values, labels
+
+    generic = re.search(
+        r"(\d+(?:\.\d+)?)%\s*in\s*last\s*5\s*seconds.*?"
+        r"(\d+(?:\.\d+)?)%\s*in\s*last\s*1\s*minute.*?"
+        r"(\d+(?:\.\d+)?)%\s*in\s*last\s*5\s*minutes",
+        output,
+        re.IGNORECASE | re.DOTALL,
+    )
+    if generic:
+        return [float(generic.group(i)) for i in range(1, 4)], ["5s", "1m", "5m"]
+
+    textual = re.search(
+        r"Five\s*seconds:\s*(\d+(?:\.\d+)?)%.*?"
+        r"One\s*minute:\s*(\d+(?:\.\d+)?)%.*?"
+        r"Five\s*minutes:\s*(\d+(?:\.\d+)?)%",
+        output,
+        re.IGNORECASE | re.DOTALL,
+    )
+    if textual:
+        return [float(textual.group(i)) for i in range(1, 4)], ["5s", "1m", "5m"]
+
+    idle_match = re.search(r"idle[^0-9]*?(\d+(?:\.\d+)?)\s*%", output, re.IGNORECASE)
+    if idle_match:
+        load = 100.0 - float(idle_match.group(1))
+        return [load], ["Now"]
+
+    return [], []
+
+
+class CpuUsageRule(BaseAuditRule):
+    @property
+    def name(self) -> str:
+        return "cpu_usage"
+
+    def run(self, info: dict) -> dict:
+        connection = info.get("connection") or info.get("shell")
+        if connection is None:
+            return {"name": self.name, "passed": False, "details": "Connexion SSH indisponible"}
+
+        disable_paging(
+            connection,
+            normalize_list(self.config.get("disable_paging", "screen-length 0 temporary,screen-length disable,no page,terminal length 0")),
+        )
+
+        commands = normalize_list(
+            self.config.get(
+                "commands",
+                "display cpu-usage,display cpu,show cpu,show processes cpu,show processes cpu history",
+            )
+        )
+
+        used_cmd: str | None = None
+        output = ""
+        for command in commands:
+            output = run_command_with_paging(connection, command)
+            values, labels = parse_cpu_output(output)
+            if values:
+                used_cmd = command
+                break
+        else:
+            values, labels = [], []
+
+        if not values:
+            return {
+                "name": self.name,
+                "passed": False,
+                "details": "Aucune métrique CPU détectée",
+            }
+
+        average = mean(values)
+        peak = max(values)
+
+        average_threshold = float(self.config.get("average_threshold", 80))
+        peak_threshold = float(self.config.get("peak_threshold", 90))
+
+        passed = average <= average_threshold and peak <= peak_threshold
+
+        metrics = ", ".join(f"{label}:{value:.1f}%" for label, value in zip(labels, values))
+        details = (
+            f"CPU OK ({metrics}) - moyenne {average:.1f}% / pic {peak:.1f}%"
+            if passed
+            else (
+                f"CPU élevée ({metrics}) - seuils moy {average_threshold:.1f}% / pic {peak_threshold:.1f}%"
+            )
+        )
+
+        if used_cmd:
+            details += f" via {used_cmd}"
+
+        return {"name": self.name, "passed": passed, "details": details}

--- a/audit/rules/fan_health.py
+++ b/audit/rules/fan_health.py
@@ -1,0 +1,70 @@
+"""Contrôle de l'état des ventilateurs."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional, Tuple
+
+from .base_rules import BaseAuditRule
+from ..utils import disable_paging, normalize_list, run_command_with_paging
+
+
+def analyse_fans(output: str) -> Tuple[Optional[int], Optional[int]]:
+    lines = output.strip().splitlines()
+    relevant = [line for line in lines if re.search(r"(Normal|Abnormal|Faulty|Absent)", line, re.IGNORECASE)]
+    total = len(relevant)
+    ok = sum(1 for line in relevant if re.search(r"Normal", line, re.IGNORECASE))
+    if total > 0:
+        return ok, total
+
+    failure_match = re.search(r"(\d+)\s*/\s*(\d+)\s*Fans in Failure State", output)
+    if failure_match:
+        ko = int(failure_match.group(1))
+        total = int(failure_match.group(2))
+        return total - ko, total
+
+    ratio = re.search(r"(\d+)\s*/\s*(\d+)", output)
+    if ratio:
+        return int(ratio.group(1)), int(ratio.group(2))
+
+    return None, None
+
+
+class FanHealthRule(BaseAuditRule):
+    @property
+    def name(self) -> str:
+        return "fan_health"
+
+    def run(self, info: dict) -> dict:
+        connection = info.get("connection") or info.get("shell")
+        if connection is None:
+            return {"name": self.name, "passed": False, "details": "Connexion SSH indisponible"}
+
+        disable_paging(
+            connection,
+            normalize_list(self.config.get("disable_paging", "screen-length disable,screen-length 0 temporary,no page")),
+        )
+
+        commands = normalize_list(self.config.get("commands", "display fan,display device,show system fans"))
+
+        for command in commands:
+            output = run_command_with_paging(connection, command)
+            ok, total = analyse_fans(output)
+            if ok is not None and total is not None:
+                passed = total == 0 or ok == total
+                if total == 0:
+                    details = f"Aucun ventilateur détecté via {command}"
+                    return {"name": self.name, "passed": True, "details": details}
+
+                details = (
+                    f"Ventilateurs {ok}/{total} OK via {command}"
+                    if passed
+                    else f"Anomalie ventilateurs {ok}/{total} via {command}"
+                )
+
+                if not passed:
+                    details += " - vérifier les modules de refroidissement"
+
+                return {"name": self.name, "passed": passed, "details": details}
+
+        return {"name": self.name, "passed": False, "details": "Aucune donnée ventilateurs exploitable"}

--- a/audit/rules/hardware_inventory.py
+++ b/audit/rules/hardware_inventory.py
@@ -1,0 +1,189 @@
+"""Inventaire matériel simplifié."""
+
+from __future__ import annotations
+
+import re
+from typing import Tuple
+
+from .base_rules import BaseAuditRule
+from ..utils import disable_paging, normalize_list, run_command_with_paging
+
+CSI = re.compile(r"\x1B\[[0-9;?]*[ -/]*[@-~]")
+ESC = re.compile(r"\x1B[@-Z\\-_]")
+CTL = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f]")
+
+
+def clean_output(text: str) -> str:
+    if not text:
+        return ""
+    text = CSI.sub("", text)
+    text = ESC.sub("", text)
+    text = CTL.sub("", text)
+    text = text.replace("\r", "")
+    text = re.sub(r"^\s*Press any key.*$", "", text, flags=re.IGNORECASE | re.MULTILINE)
+    return text
+
+
+def detect_model(text: str) -> str:
+    t = clean_output(text)
+    match = re.search(
+        r"^(?:HPE|HP|H3C|Huawei|Aruba|Cisco)\s+([^\n]+?)\s+with\b",
+        t,
+        re.IGNORECASE | re.MULTILINE,
+    )
+    if match:
+        base = match.group(1).strip()
+        pn = re.search(r"\b(J[HL]\d{3,}[A-Z]?)\b", t, re.IGNORECASE)
+        if pn:
+            part = pn.group(0).upper()
+            if part not in base:
+                base = f"{base} {part}"
+        base = re.sub(r"\s+(Switch|Router)\s*$", "", base, flags=re.IGNORECASE)
+        return base
+
+    explicit = re.search(
+        r"(?:Product\s*Name|Model|Device\s*model|Device\s*type|BOARD\s*TYPE)\s*:\s*([^\n]+)",
+        t,
+        re.IGNORECASE,
+    )
+    if explicit:
+        return explicit.group(1).strip()
+
+    chassis = re.search(r"^\s*Chassis\s*:\s*([^\n]+)$", t, re.IGNORECASE | re.MULTILINE)
+    if chassis:
+        return chassis.group(1).strip()
+
+    hi = re.search(r"\b([0-9]{3,4}.*?(?:HI|EI)[^\n]*)", t, re.IGNORECASE)
+    if hi:
+        return hi.group(1).strip()
+
+    aruba = re.search(r"\b(2930F[-\w +]*)\b", t, re.IGNORECASE)
+    if aruba:
+        return f"Aruba {aruba.group(1)}"
+
+    huawei = re.search(r"\b(AR\d{3,}[A-Z]?)\b", t, re.IGNORECASE)
+    if huawei:
+        return huawei.group(1).upper()
+
+    family = re.search(r"\bS\d{4}[A-Z0-9\-]*\b", t, re.IGNORECASE)
+    if family:
+        return family.group(0).upper()
+
+    hp = re.search(r"\bHP\s*(\d{3,4}\w*)\b", t, re.IGNORECASE)
+    if hp:
+        return f"HP {hp.group(1)}"
+
+    software = re.search(r"^(.*Software.*)$", t, re.IGNORECASE | re.MULTILINE)
+    if software:
+        return software.group(1).strip()
+
+    return "N/A"
+
+
+def detect_version(text: str) -> Tuple[str, str]:
+    t = clean_output(text)
+
+    comware7 = re.search(
+        r"Comware\s+Software,\s*Version\s*([0-9A-Za-z.\-]+)\s*,\s*Release\s*([0-9A-Za-z]+)",
+        t,
+        re.IGNORECASE,
+    )
+    if comware7:
+        base = comware7.group(1).strip()
+        release = comware7.group(2).strip()
+        return base, f"{base}, Release {release}"
+
+    comware5 = re.search(
+        r"\bVersion\s*([0-9]+\.[0-9A-Za-z.]+)\s*,\s*Release\s*([0-9A-Za-z]+)",
+        t,
+        re.IGNORECASE,
+    )
+    if comware5:
+        base = comware5.group(1).strip()
+        release = comware5.group(2).strip()
+        return base, f"{base}, Release {release}"
+
+    vrp = re.search(r"\bVersion\s*([0-9A-Za-z.\-]+)\s*(\([^)]+\))", t, re.IGNORECASE)
+    if vrp:
+        base = vrp.group(1).strip()
+        return base, f"{base} {vrp.group(2).strip()}"
+
+    aruba = re.search(r"(?:Software\s+revision|Software\s+Version)\s*:\s*([^\n]+)", t, re.IGNORECASE)
+    if aruba:
+        base = aruba.group(1).strip()
+        return base, base
+
+    generic = re.search(r"\bVersion\s*:\s*([^\n]+)", t, re.IGNORECASE)
+    if generic:
+        full = generic.group(1).strip()
+        prefix = re.match(r"([0-9A-Za-z.\-]+)", full)
+        version = prefix.group(1).strip() if prefix else full
+        return version, full
+
+    return "N/A", "N/A"
+
+
+class HardwareInventoryRule(BaseAuditRule):
+    @property
+    def name(self) -> str:
+        return "hardware_inventory"
+
+    def run(self, info: dict) -> dict:
+        connection = info.get("connection") or info.get("shell")
+        if connection is None:
+            return {"name": self.name, "passed": False, "details": "Connexion SSH indisponible"}
+
+        disable_paging(
+            connection,
+            normalize_list(self.config.get("disable_paging", "screen-length disable,screen-length 0 temporary,no page")),
+        )
+
+        commands = normalize_list(
+            self.config.get("commands", "display version,show system,show version,show system information")
+        )
+
+        primary_output = ""
+        used_command = None
+        tried = []
+        for command in commands:
+            tried.append(command)
+            output = clean_output(run_command_with_paging(connection, command))
+            if not output or re.search(r"(Invalid|Unrecognized|Incomplete input)", output, re.IGNORECASE):
+                continue
+            if not primary_output:
+                primary_output = output
+                used_command = command
+
+        if not primary_output:
+            return {
+                "name": self.name,
+                "passed": False,
+                "details": f"Aucune sortie exploitable (commandes testées: {', '.join(tried)})",
+            }
+
+        model = detect_model(primary_output)
+        version, firmware = detect_version(primary_output)
+
+        if model == "N/A":
+            extra_commands = normalize_list(
+                self.config.get("extra_commands", "display device manuinfo,display device,show inventory")
+            )
+            for command in extra_commands:
+                extra_output = clean_output(run_command_with_paging(connection, command))
+                if not extra_output or re.search(r"(Invalid|Unrecognized|Incomplete input)", extra_output, re.IGNORECASE):
+                    continue
+                detected = detect_model(extra_output)
+                if detected != "N/A":
+                    model = detected
+                    break
+
+        details = (
+            f"Modèle: {model} | Version: {version} | Firmware: {firmware}"
+            + (f" via {used_command}" if used_command else "")
+        )
+
+        passed = model != "N/A" and version != "N/A"
+        if not passed:
+            details += " - informations partielles"
+
+        return {"name": self.name, "passed": passed, "details": details}

--- a/audit/rules/memory_usage.py
+++ b/audit/rules/memory_usage.py
@@ -1,0 +1,67 @@
+"""Contrôle du taux d'utilisation mémoire."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from .base_rules import BaseAuditRule
+from ..utils import disable_paging, normalize_list, run_command_with_paging
+
+
+def extract_usage_percent(output: str) -> Optional[float]:
+    match = re.search(r"(\d+(?:\.\d+)?)\s*%", output)
+    if match:
+        try:
+            return float(match.group(1))
+        except ValueError:  # pragma: no cover - sécurité supplémentaire
+            return None
+    return None
+
+
+class MemoryUsageRule(BaseAuditRule):
+    @property
+    def name(self) -> str:
+        return "memory_usage"
+
+    def run(self, info: dict) -> dict:
+        connection = info.get("connection") or info.get("shell")
+        if connection is None:
+            return {"name": self.name, "passed": False, "details": "Connexion SSH indisponible"}
+
+        disable_paging(
+            connection,
+            normalize_list(self.config.get("disable_paging", "screen-length 0 temporary,screen-length disable,no page")),
+        )
+
+        commands = normalize_list(
+            self.config.get("commands", "display memory,display memory-usage,display system resource")
+        )
+
+        percent: Optional[float] = None
+        used_cmd = None
+        for command in commands:
+            output = run_command_with_paging(connection, command)
+            percent = extract_usage_percent(output)
+            if percent is not None:
+                used_cmd = command
+                break
+
+        if percent is None:
+            return {
+                "name": self.name,
+                "passed": False,
+                "details": "Aucun pourcentage d'utilisation mémoire détecté",
+            }
+
+        threshold = float(self.config.get("threshold", 85.0))
+        passed = percent <= threshold
+        details = (
+            f"Utilisation mémoire {percent:.1f}% (seuil {threshold:.1f}%)"
+            + (f" via {used_cmd}" if used_cmd else "")
+        )
+
+        if not passed:
+            details += " - capacité mémoire élevée"
+
+        return {"name": self.name, "passed": passed, "details": details}

--- a/audit/rules/power_supply.py
+++ b/audit/rules/power_supply.py
@@ -1,0 +1,81 @@
+"""Contrôle des alimentations électriques."""
+
+from __future__ import annotations
+
+import re
+from typing import Tuple
+
+from .base_rules import BaseAuditRule
+from ..utils import disable_paging, normalize_list, run_command_with_paging
+
+
+def analyse_power(output: str) -> Tuple[int, int, int, int]:
+    ok = len(re.findall(r"\b(Normal|OK|Present|Powered|Active)\b", output, re.IGNORECASE))
+    fault = len(re.findall(r"\b(Fault|Abnormal|Fail|Defect|Error)\b", output, re.IGNORECASE))
+    absent = len(re.findall(r"\b(Absent|Not Present|Missing)\b", output, re.IGNORECASE))
+
+    resume = re.search(r"\((\d+)\s+fault\(s\),\s+(\d+)\s+absent\(s\),\s+(\d+)\s+OK\)", output)
+    if resume:
+        fault, absent, ok = (int(resume.group(i)) for i in range(1, 4))
+
+    bays = re.search(r"(\d+)\s*/\s*(\d+)\s*supply bays delivering power", output, re.IGNORECASE)
+    if bays:
+        ok = int(bays.group(1))
+        total = int(bays.group(2))
+        absent = max(0, total - ok)
+        return ok, fault, absent, total
+
+    total = ok + fault + absent
+    return ok, fault, absent, total
+
+
+class PowerSupplyRule(BaseAuditRule):
+    @property
+    def name(self) -> str:
+        return "power_supply"
+
+    def run(self, info: dict) -> dict:
+        connection = info.get("connection") or info.get("shell")
+        if connection is None:
+            return {"name": self.name, "passed": False, "details": "Connexion SSH indisponible"}
+
+        disable_paging(
+            connection,
+            normalize_list(self.config.get("disable_paging", "screen-length 0 temporary,no page")),
+        )
+
+        commands = normalize_list(
+            self.config.get("commands", "display power,show system power-supply,show environment power")
+        )
+
+        for command in commands:
+            output = run_command_with_paging(connection, command)
+            if not output:
+                continue
+            if "does not support" in output.lower():
+                return {
+                    "name": self.name,
+                    "passed": True,
+                    "details": f"Équipement sans capteurs d'alimentation (commande {command})",
+                }
+
+            ok, fault, absent, total = analyse_power(output)
+            if total == 0:
+                continue
+
+            passed = fault == 0 and ok > 0
+            if absent > 0 and passed:
+                passed = False
+
+            details = (
+                f"Alimentations OK {ok}/{total} via {command}"
+                if passed
+                else f"Alimentations partielles {ok}/{total} (fault:{fault}, absent:{absent}) via {command}"
+            )
+
+            if not passed and ok == 0:
+                details += " - aucune alimentation active"
+
+            return {"name": self.name, "passed": passed, "details": details}
+
+        return {"name": self.name, "passed": False, "details": "Aucune donnée alimentation exploitable"}

--- a/audit/rules/storage_capacity.py
+++ b/audit/rules/storage_capacity.py
@@ -1,0 +1,122 @@
+"""Contrôle de l'espace de stockage et des firmwares présents."""
+
+from __future__ import annotations
+
+import re
+from typing import List, Optional, Tuple
+
+from .base_rules import BaseAuditRule
+from ..utils import disable_paging, normalize_list, run_command_with_paging
+
+
+def extract_disk_usage(output: str) -> Tuple[Optional[int], Optional[int]]:
+    for line in output.splitlines():
+        match = re.search(
+            r"([\d,]+)\s*KB\s+total(?:\s+available)?\s*\(\s*([\d,]+)\s*KB\s+free",
+            line,
+            flags=re.IGNORECASE,
+        )
+        if match:
+            try:
+                total = int(match.group(1).replace(",", ""))
+                free = int(match.group(2).replace(",", ""))
+                return total, free
+            except ValueError:
+                continue
+    return None, None
+
+
+def extract_firmwares(output: str) -> List[Tuple[str, int]]:
+    firmwares: List[Tuple[str, int]] = []
+    for line in output.splitlines():
+        lower = line.lower()
+        if not any(ext in lower for ext in (".bin", ".cc", ".img", ".ipe")):
+            continue
+
+        file_match = re.search(r"(\S+\.(?:bin|cc|img|ipe))", line, re.IGNORECASE)
+        if not file_match:
+            continue
+
+        size_match = re.search(r"-rw-\s+([\d,]+)", line)
+        size_value: Optional[int] = None
+        if size_match:
+            try:
+                size_value = int(size_match.group(1).replace(",", ""))
+            except ValueError:
+                size_value = None
+
+        if size_value is None:
+            candidates = []
+            for candidate in re.findall(r"([\d,]+)", line):
+                try:
+                    candidates.append(int(candidate.replace(",", "")))
+                except ValueError:
+                    continue
+            if candidates:
+                size_value = max(candidates)
+
+        if size_value is not None:
+            firmwares.append((file_match.group(1), size_value))
+
+    return firmwares
+
+
+class StorageCapacityRule(BaseAuditRule):
+    @property
+    def name(self) -> str:
+        return "storage_capacity"
+
+    def run(self, info: dict) -> dict:
+        connection = info.get("connection") or info.get("shell")
+        if connection is None:
+            return {"name": self.name, "passed": False, "details": "Connexion SSH indisponible"}
+
+        disable_paging(
+            connection,
+            normalize_list(
+                self.config.get(
+                    "disable_paging",
+                    "screen-length 0 temporary,screen-length disable,no page,terminal length 0",
+                )
+            ),
+        )
+
+        commands = normalize_list(self.config.get("commands", "dir,show flash,display flash"))
+
+        for command in commands:
+            output = run_command_with_paging(connection, command)
+            if not output.strip():
+                continue
+            if any(keyword in output for keyword in ("Unrecognized", "Invalid", "Unknown command")):
+                continue
+
+            total_kb, free_kb = extract_disk_usage(output)
+            firmwares = extract_firmwares(output)
+
+            if free_kb is not None and firmwares:
+                firmware_name, firmware_size = max(firmwares, key=lambda item: item[1])
+                firmware_kb = firmware_size / 1024
+                passed = free_kb > firmware_kb
+                details = (
+                    f"Libre: {free_kb} KB | Firmware max: {firmware_name} ({firmware_kb:.0f} KB) via {command}"
+                )
+                if not passed:
+                    details += " - espace insuffisant"
+                return {"name": self.name, "passed": passed, "details": details}
+
+            if free_kb is None and firmwares:
+                firmware_name, firmware_size = max(firmwares, key=lambda item: item[1])
+                details = (
+                    f"Firmware {firmware_name} ({firmware_size} B) détecté via {command}"
+                    " - incapacité à vérifier l'espace libre"
+                )
+                return {"name": self.name, "passed": False, "details": details}
+
+            if free_kb is not None and not firmwares:
+                return {
+                    "name": self.name,
+                    "passed": True,
+                    "details": f"Libre: {free_kb} KB - aucun firmware détecté via {command}",
+                }
+
+        return {"name": self.name, "passed": False, "details": "Aucune information de stockage exploitable"}

--- a/audit/rules/temperature.py
+++ b/audit/rules/temperature.py
@@ -1,0 +1,188 @@
+"""Contrôle des températures d'équipement."""
+
+from __future__ import annotations
+
+import re
+from typing import List, Optional, Tuple
+
+from .base_rules import BaseAuditRule
+from ..utils import disable_paging, normalize_list, run_command_with_paging
+
+
+def _is_separator(line: str) -> bool:
+    return bool(re.match(r"^\s*-{3,}\s*$", line))
+
+
+def _is_prompt(line: str) -> bool:
+    return bool(re.match(r"^<.*?>$", line.strip()))
+
+
+def _compute_columns(header_line: str) -> List[Tuple[str, int, int]]:
+    columns: List[Tuple[str, int, int]] = []
+    length = len(header_line)
+    idx = 0
+    start: Optional[int] = None
+
+    while idx < length:
+        if start is None and header_line[idx] != " ":
+            start = idx
+        elif start is not None and header_line[idx] == " ":
+            end = idx
+            while idx < length and header_line[idx] == " ":
+                idx += 1
+            name = header_line[start:end].strip().lower()
+            if name:
+                columns.append((name, start, end))
+            start = None
+            continue
+        idx += 1
+
+    if start is not None:
+        name = header_line[start:].strip().lower()
+        if name:
+            columns.append((name, start, length))
+
+    return columns
+
+
+def _slice(line: str, start: int, end: int) -> str:
+    if start >= len(line):
+        return ""
+    return line[start:min(end, len(line))].strip()
+
+
+def _find_column(columns: List[Tuple[str, int, int]], keys: List[str]) -> Optional[Tuple[int, int]]:
+    for key in keys:
+        for name, start, end in columns:
+            if key in name:
+                return start, end
+    return None
+
+
+def _parse_table(lines: List[str]) -> Tuple[List[float], Optional[float], Optional[float], Optional[float]]:
+    header_index = None
+    for idx, line in enumerate(lines):
+        low = line.lower()
+        if "information" in low:
+            continue
+        if re.search(r"\btemperature\b", low) or "temp(c)" in low:
+            if len(re.split(r"\s{2,}", line.strip())) >= 2:
+                header_index = idx
+                break
+
+    if header_index is None:
+        return [], None, None, None
+
+    columns = _compute_columns(lines[header_index])
+    if not columns:
+        return [], None, None, None
+
+    temp_span = _find_column(columns, ["temperature", "temp", "temp(c)"])
+    warn_span = _find_column(columns, ["warning", "upper", "warninglimit"])
+    alarm_span = _find_column(columns, ["alarm", "shutdown"])
+    lower_span = _find_column(columns, ["lower", "lowerlimit"])
+
+    if temp_span is None:
+        return [], None, None, None
+
+    temps: List[float] = []
+    warns: List[float] = []
+    alarms: List[float] = []
+    lowers: List[float] = []
+
+    for line in lines[header_index + 1 :]:
+        stripped = line.strip()
+        if not stripped or _is_separator(stripped) or _is_prompt(stripped):
+            continue
+
+        match = re.search(r"-?\d+(?:\.\d+)?", _slice(line, *temp_span))
+        if match:
+            temps.append(float(match.group(0)))
+
+        for span, container in (
+            (warn_span, warns),
+            (alarm_span, alarms),
+            (lower_span, lowers),
+        ):
+            if span:
+                value_match = re.search(r"-?\d+(?:\.\d+)?", _slice(line, *span))
+                if value_match:
+                    container.append(float(value_match.group(0)))
+
+    if not temps:
+        return [], None, None, None
+
+    lower = min(lowers) if lowers else None
+    warn = min(warns) if warns else None
+    alarm = min(alarms) if alarms else None
+    return temps, lower, warn, alarm
+
+
+def _parse_text(output: str) -> Tuple[List[float], Optional[float], Optional[float], Optional[float]]:
+    temps = [float(m.group(1)) for m in re.finditer(r"(-?\d+(?:\.\d+)?)\s*°?\s*C", output, re.IGNORECASE)]
+
+    def grab(tag: str) -> Optional[float]:
+        match = re.search(fr"{tag}[^0-9-]*(-?\d+(?:\.\d+)?)\s*°?\s*C", output, re.IGNORECASE)
+        return float(match.group(1)) if match else None
+
+    warn = grab("warning") or grab("upper")
+    alarm = grab("alarm")
+    lower = grab("lower")
+    return temps, lower, warn, alarm
+
+
+def parse_temperatures(output: str) -> Tuple[List[float], Optional[float], Optional[float], Optional[float]]:
+    lines = output.splitlines()
+    temps, lower, warn, alarm = _parse_table(lines)
+    if temps or any(v is not None for v in (lower, warn, alarm)):
+        return temps, lower, warn, alarm
+    return _parse_text(output)
+
+
+class TemperatureRule(BaseAuditRule):
+    @property
+    def name(self) -> str:
+        return "temperature"
+
+    def run(self, info: dict) -> dict:
+        connection = info.get("connection") or info.get("shell")
+        if connection is None:
+            return {"name": self.name, "passed": False, "details": "Connexion SSH indisponible"}
+
+        disable_paging(
+            connection,
+            normalize_list(self.config.get("disable_paging", "screen-length 0 temporary,screen-length disable")),
+        )
+
+        commands = normalize_list(
+            self.config.get("commands", "display temperature all,display env,display environment")
+        )
+
+        for command in commands:
+            output = run_command_with_paging(connection, command)
+            if not output.strip():
+                continue
+
+            temps, lower, warn, alarm = parse_temperatures(output)
+            if not temps:
+                continue
+
+            thresholds = [value for value in (warn, alarm) if value is not None]
+            threshold = min(thresholds) if thresholds else float(self.config.get("default_threshold", 60))
+            max_temp = max(temps)
+            passed = max_temp <= threshold
+
+            def _fmt(value: Optional[float]) -> str:
+                return f"{value:.1f}°C" if value is not None else "NA"
+
+            details = (
+                f"Température max {max_temp:.1f}°C (seuil {threshold:.1f}°C) via {command}"
+                f" | Lower:{_fmt(lower)} Warning:{_fmt(warn)} Alarm:{_fmt(alarm)}"
+            )
+
+            if not passed:
+                details += " - dépassement de seuil"
+
+            return {"name": self.name, "passed": passed, "details": details}
+
+        return {"name": self.name, "passed": False, "details": "Aucune mesure de température disponible"}

--- a/audit/rules/transceiver_diagnostics.py
+++ b/audit/rules/transceiver_diagnostics.py
@@ -1,0 +1,115 @@
+"""Contrôle des modules SFP et mesures optiques."""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, List, Tuple
+
+from .base_rules import BaseAuditRule
+from ..utils import disable_paging, normalize_list, run_command_with_paging
+
+
+def parse_transceivers(output: str) -> List[Dict[str, object]]:
+    blocks = re.finditer(
+        r"(?P<port>(?:GigabitEthernet|Ten[- ]?GigabitEthernet|Forty[- ]?GigabitEthernet|Hundred[- ]?GigE)\S+)"
+        r"\s+transceiver\s+diagnostic\s+information:\s*"
+        r"(?P<info>.*?)(?=(?:GigabitEthernet|Ten[- ]?GigabitEthernet|Forty[- ]?GigabitEthernet|Hundred[- ]?GigE)|$)",
+        output,
+        re.IGNORECASE | re.DOTALL,
+    )
+
+    regex_value = re.compile(
+        r"(Temperature|Voltage|Bias\s*Current|RX\s*Power|TX\s*Power)\s*[:=]\s*([-]?\d+(?:\.\d+)?)"
+        r".*?(?:Threshold|Range|Warning)\s*[:=]?\s*([-]?\d+(?:\.\d+)?)\s*(?:to|\.{2})\s*([-]?\d+(?:\.\d+)?)",
+        re.IGNORECASE | re.DOTALL,
+    )
+
+    transceivers: List[Dict[str, object]] = []
+    for match in blocks:
+        port = match.group("port")
+        info = (match.group("info") or "").strip()
+        present = True
+        measurements: List[Tuple[str, float, float, float, bool]] = []
+
+        if re.search(r"(transceiver\s+is\s+absent|Error:\s*The\s+transceiver\s+is\s+absent)", info, re.IGNORECASE):
+            present = False
+        else:
+            for value_match in regex_value.finditer(info):
+                metric = value_match.group(1).strip()
+                try:
+                    val = float(value_match.group(2))
+                    vmin = float(value_match.group(3))
+                    vmax = float(value_match.group(4))
+                except ValueError:
+                    continue
+                ok = vmin <= val <= vmax
+                measurements.append((metric, val, vmin, vmax, ok))
+            if not measurements:
+                present = bool(re.search(r"present", info, re.IGNORECASE))
+
+        transceivers.append({"port": port, "present": present, "measurements": measurements})
+
+    return transceivers
+
+
+class TransceiverDiagnosticsRule(BaseAuditRule):
+    @property
+    def name(self) -> str:
+        return "transceiver_diagnostics"
+
+    def run(self, info: dict) -> dict:
+        connection = info.get("connection") or info.get("shell")
+        if connection is None:
+            return {"name": self.name, "passed": False, "details": "Connexion SSH indisponible"}
+
+        disable_paging(
+            connection,
+            normalize_list(self.config.get("disable_paging", "screen-length disable")),
+        )
+
+        commands = normalize_list(
+            self.config.get(
+                "commands",
+                "display transceiver diagnosis interface,display transceiver,show interfaces transceiver",
+            )
+        )
+
+        all_alerts: List[str] = []
+
+        for command in commands:
+            output = run_command_with_paging(connection, command)
+            if not output.strip():
+                continue
+            if "Invalid" in output or "Unrecognized" in output:
+                continue
+
+            transceivers = parse_transceivers(output)
+            if not transceivers:
+                continue
+
+            absent = sum(1 for t in transceivers if not t["present"])
+            present = sum(1 for t in transceivers if t["present"])
+            details_parts = [f"SFP présents: {present}", f"absents: {absent}", f"commande: {command}"]
+
+            for transceiver in transceivers:
+                port = transceiver["port"]
+                if not transceiver["present"]:
+                    details_parts.append(f"{port}: absent")
+                    continue
+                measurements = transceiver["measurements"]
+                if not measurements:
+                    details_parts.append(f"{port}: présent sans mesure")
+                    continue
+                for metric, value, vmin, vmax, ok in measurements:
+                    if not ok:
+                        alert = f"{port} {metric}={value} (seuil {vmin}..{vmax})"
+                        all_alerts.append(alert)
+                        details_parts.append(f"ALERTE {alert}")
+
+            passed = not all_alerts
+            details = "; ".join(details_parts)
+            if not passed:
+                details += " - mesures hors plage"
+            return {"name": self.name, "passed": passed, "details": details}
+
+        return {"name": self.name, "passed": False, "details": "Aucune donnée transceiver disponible"}

--- a/audit/rules/uptime.py
+++ b/audit/rules/uptime.py
@@ -1,0 +1,102 @@
+"""Contrôle de l'uptime des équipements."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from .base_rules import BaseAuditRule
+from ..utils import disable_paging, normalize_list, run_command_with_paging
+
+
+def parse_uptime(output: str) -> tuple[Optional[str], Optional[str], int]:
+    reason_match = re.search(
+        r"(Last\s+reboot\s+reason\s*:\s*(.+))|(Reboot\s+Cause\s*:\s*(.+))",
+        output,
+        re.IGNORECASE,
+    )
+    reason = (reason_match.group(2) or reason_match.group(4) or "NA").strip() if reason_match else "NA"
+
+    uptime_match = (
+        re.search(r"\buptime\s+is\s+(.+)", output, re.IGNORECASE)
+        or re.search(r"\bUptime\s+is\s+(.+)", output, re.IGNORECASE)
+        or re.search(r"\bUp\s*Time\s*[:=]\s*(.+)", output, re.IGNORECASE)
+    )
+
+    if not uptime_match:
+        return None, reason, 0
+
+    uptime_str = uptime_match.group(1).strip()
+    uptime_str = re.split(r"\s{2,}(Memory|CPU|Base|Software|ROM)", uptime_str)[0].strip()
+
+    weeks = days = hours = minutes = 0
+    pattern = re.search(
+        r"(?:(\d+)\s*weeks?)?\s*,?\s*"
+        r"(?:(\d+)\s*days?)?\s*,?\s*"
+        r"(?:(\d+)\s*hours?)?\s*,?\s*"
+        r"(?:(\d+)\s*minutes?)?",
+        uptime_str,
+        re.IGNORECASE,
+    )
+    if pattern:
+        weeks = int(pattern.group(1) or 0)
+        days = int(pattern.group(2) or 0)
+        hours = int(pattern.group(3) or 0)
+        minutes = int(pattern.group(4) or 0)
+    else:
+        m_days = re.search(r"(\d+)\s*days?", uptime_str, re.IGNORECASE)
+        if m_days:
+            days = int(m_days.group(1))
+
+    total_seconds = weeks * 7 * 86400 + days * 86400 + hours * 3600 + minutes * 60
+    formatted = (
+        f"{weeks} weeks, {days} days, {hours} hours, {minutes} minutes"
+        if (weeks + days + hours + minutes) > 0
+        else uptime_str
+    )
+
+    return formatted, reason, total_seconds
+
+
+class UptimeRule(BaseAuditRule):
+    @property
+    def name(self) -> str:
+        return "uptime"
+
+    def run(self, info: dict) -> dict:
+        connection = info.get("connection") or info.get("shell")
+        if connection is None:
+            return {"name": self.name, "passed": False, "details": "Connexion SSH indisponible"}
+
+        disable_paging(
+            connection,
+            normalize_list(self.config.get("disable_paging", "screen-length disable")),
+        )
+
+        commands = normalize_list(
+            self.config.get(
+                "commands",
+                "display version,show version,show system information,show system",
+            )
+        )
+
+        for command in commands:
+            output = run_command_with_paging(connection, command)
+            if not output:
+                continue
+
+            uptime_str, reason, total_seconds = parse_uptime(output)
+            if uptime_str is None:
+                continue
+
+            threshold = int(self.config.get("minimum_seconds", 86400))
+            passed = total_seconds >= threshold
+            details = (
+                f"Uptime {uptime_str} (raison reboot: {reason}) via {command}"
+                if passed
+                else f"Reboot récent ({uptime_str}) - seuil {threshold // 3600}h via {command}"
+            )
+
+            return {"name": self.name, "passed": passed, "details": details}
+
+        return {"name": self.name, "passed": False, "details": "Aucune information d'uptime"}

--- a/audit/utils.py
+++ b/audit/utils.py
@@ -1,0 +1,68 @@
+"""Fonctions utilitaires communes aux règles d'audit."""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable, List, Sequence
+
+LOGGER = logging.getLogger(__name__)
+
+
+MORE_TOKENS_DEFAULT: Sequence[str] = (
+    "---- More ----",
+    "--More--",
+    "More:",
+    "<--- More --->",
+)
+
+
+def normalize_list(value: str | Iterable[str], separator: str = ",") -> List[str]:
+    """Normalise une liste issue d'une configuration."""
+
+    if isinstance(value, str):
+        items = [part.strip() for part in value.split(separator)]
+    else:
+        items = [str(part).strip() for part in value]
+    return [item for item in items if item]
+
+
+def disable_paging(connection, commands: Sequence[str]) -> None:
+    """Désactive la pagination sur la connexion Netmiko fournie."""
+
+    for command in commands:
+        try:
+            connection.send_command_timing(command)
+        except Exception:  # pragma: no cover - dépend de l'équipement
+            continue
+
+
+def run_command_with_paging(connection, command: str, more_tokens: Sequence[str] | None = None) -> str:
+    """Exécute une commande en gérant les prompts "More"."""
+
+    tokens = more_tokens or MORE_TOKENS_DEFAULT
+    output = connection.send_command_timing(command)
+    if not output:
+        return ""
+    while any(marker in output for marker in tokens):
+        for marker in tokens:
+            output = output.replace(marker, "")
+        output += connection.send_command_timing(" ")
+    return output
+
+
+def first_successful_command(connection, commands: Sequence[str]) -> tuple[str | None, str]:
+    """Tente une liste de commandes et retourne la première sortie exploitable."""
+
+    for command in commands:
+        try:
+            output = run_command_with_paging(connection, command)
+        except Exception as exc:  # pragma: no cover - dépend des équipements
+            LOGGER.debug("Commande '%s' en échec: %s", command, exc)
+            continue
+        if not output or not output.strip():
+            continue
+        lowered = output.lower()
+        if "unrecognized" in lowered or "invalid" in lowered or "unknown command" in lowered:
+            continue
+        return command, output
+    return None, ""

--- a/config/cpu_usage.ini
+++ b/config/cpu_usage.ini
@@ -1,0 +1,5 @@
+[cpu_usage]
+disable_paging = screen-length 0 temporary,screen-length disable,no page,terminal length 0
+commands = display cpu-usage,display cpu,show cpu,show processes cpu,show processes cpu history
+average_threshold = 80
+peak_threshold = 90

--- a/config/fan_health.ini
+++ b/config/fan_health.ini
@@ -1,0 +1,3 @@
+[fan_health]
+disable_paging = screen-length disable,screen-length 0 temporary,no page
+commands = display fan,display device,show system fans

--- a/config/hardware_inventory.ini
+++ b/config/hardware_inventory.ini
@@ -1,0 +1,4 @@
+[hardware_inventory]
+disable_paging = screen-length disable,screen-length 0 temporary,no page
+commands = display version,show system,show version,show system information
+extra_commands = display device manuinfo,display device,show inventory

--- a/config/main.ini
+++ b/config/main.ini
@@ -1,0 +1,10 @@
+[audit]
+log_level = INFO
+workers = 50
+ips_file = config/ips.txt
+output_dir = results
+active_rules = sysname,tacacs,snmp_v3_check,snmp_trap_check,cpu_usage,memory_usage,fan_health,power_supply,temperature,uptime,hardware_inventory,storage_capacity,transceiver_diagnostics
+
+# Valeurs SNMP par défaut (optionnelles, peuvent être surchargées en CLI)
+snmp_auth_proto = SHA
+snmp_priv_proto = AES

--- a/config/memory_usage.ini
+++ b/config/memory_usage.ini
@@ -1,0 +1,4 @@
+[memory_usage]
+disable_paging = screen-length 0 temporary,screen-length disable,no page
+commands = display memory,display memory-usage,display system resource
+threshold = 85

--- a/config/power_supply.ini
+++ b/config/power_supply.ini
@@ -1,0 +1,3 @@
+[power_supply]
+disable_paging = screen-length 0 temporary,no page
+commands = display power,show system power-supply,show environment power

--- a/config/snmp_trap_check.ini
+++ b/config/snmp_trap_check.ini
@@ -1,0 +1,5 @@
+[snmp_trap_check]
+disable_paging = screen-length 0 temporary,screen-length disable,no page
+commands = display current-configuration | include snmp
+fallback_commands = display snmp-agent trap-list
+required_targets = 10.105.29.41,10.105.30.166

--- a/config/snmp_v3_check.ini
+++ b/config/snmp_v3_check.ini
@@ -1,0 +1,7 @@
+[snmp_v3_check]
+oid = 1.3.6.1.2.1.1.3.0
+port = 161
+timeout = 5
+retries = 0
+auth_protocol = SHA
+priv_protocol = AES

--- a/config/storage_capacity.ini
+++ b/config/storage_capacity.ini
@@ -1,0 +1,3 @@
+[storage_capacity]
+disable_paging = screen-length 0 temporary,screen-length disable,no page,terminal length 0
+commands = dir,show flash,display flash

--- a/config/sysname.ini
+++ b/config/sysname.ini
@@ -1,0 +1,3 @@
+[sysname]
+prefixes = NETW,LMZFR,CLM-
+patterns = ^R\d{2}[A-Z0-9\-]*$

--- a/config/temperature.ini
+++ b/config/temperature.ini
@@ -1,0 +1,4 @@
+[temperature]
+disable_paging = screen-length 0 temporary,screen-length disable
+commands = display temperature all,display env,display environment
+default_threshold = 60

--- a/config/transceiver_diagnostics.ini
+++ b/config/transceiver_diagnostics.ini
@@ -1,0 +1,3 @@
+[transceiver_diagnostics]
+disable_paging = screen-length disable
+commands = display transceiver diagnosis interface,display transceiver,show interfaces transceiver

--- a/config/uptime.ini
+++ b/config/uptime.ini
@@ -1,0 +1,4 @@
+[uptime]
+disable_paging = screen-length disable
+commands = display version,show version,show system information,show system
+minimum_seconds = 86400

--- a/main.py
+++ b/main.py
@@ -1,144 +1,149 @@
-#!/usr/bin/env python3
-# main.py
+"""Orchestrateur des audits réseau."""
 
-import os
+from __future__ import annotations
+
+import argparse
 import csv
 import getpass
-import argparse
-from datetime import datetime
+import logging
+import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from report.dashboard import generate_html_dashboard
-from audit.runner import run_audit, ALL_RULES
+from datetime import datetime
+from pathlib import Path
+from typing import List
 
-def load_ips(path="config/ips.txt"):
+from audit.config_loader import load_main_config
+from audit.runner import instantiate_rules, run_audit
+from audit.rules import RULE_REGISTRY
+from report.dashboard import generate_html_dashboard
+
+DEFAULT_CONFIG = Path("config") / "main.ini"
+
+
+def load_ips(path: Path) -> List[str]:
     try:
-        with open(path) as f:
-            return [l.strip() for l in f if l.strip() and not l.startswith("#")]
+        with path.open(encoding="utf-8") as handle:
+            return [line.strip() for line in handle if line.strip() and not line.startswith("#")]
     except FileNotFoundError:
-        print(f"Error: IP file not found at {path}")
+        logging.error("Fichier IP introuvable: %s", path)
         return []
 
-def main():
-    parser = argparse.ArgumentParser(description="Parallel audit (selective rules)")
-    parser.add_argument("-u", "--username", required=True, help="SSH username")
-    parser.add_argument("-p", "--password", required=False, help="SSH password (prompt if not provided)")
-    parser.add_argument("-i", "--ips", default="config/ips.txt", help="IPs file (default: config/ips.txt)")
-    parser.add_argument("-r", "--rules", default=None,
-                        help=f"Comma-separated list of rules (choices: {','.join(ALL_RULES.keys())}). All if absent.")
-    parser.add_argument("-o", "--output", default=None, help="CSV output file (default: results/audit_YYYYMMDD_HHMMSS.csv)")
-    parser.add_argument("-w", "--workers", type=int, default=100, help="Number of parallel workers (default: 100)")
 
-    parser.add_argument("--snmp-user", default=os.environ.get("SNMP_USER"), help="SNMPv3 username (or ENV: SNMP_USER)")
-    parser.add_argument("--snmp-auth-key", default=os.environ.get("SNMP_AUTH_KEY"), help="SNMPv3 auth key (or ENV: SNMP_AUTH_KEY)")
-    parser.add_argument("--snmp-priv-key", default=os.environ.get("SNMP_PRIV_KEY"), help="SNMPv3 priv key (or ENV: SNMP_PRIV_KEY)")
-    parser.add_argument("--snmp-auth-proto", default=os.environ.get("SNMP_AUTH_PROTO", "SHA"), help="SNMPv3 auth protocol (default: SHA, or ENV: SNMP_AUTH_PROTO)")
-    parser.add_argument("--snmp-priv-proto", default=os.environ.get("SNMP_PRIV_PROTO", "AES"), help="SNMPv3 priv protocol (default: AES, or ENV: SNMP_PRIV_PROTO)")
+def configure_logging(level: str) -> None:
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Orchestrateur d'audits réseau modulaire")
+    parser.add_argument("-u", "--username", required=True, help="Nom d'utilisateur SSH")
+    parser.add_argument("-p", "--password", help="Mot de passe SSH (sinon saisie interactive)")
+    parser.add_argument("-c", "--config", type=Path, default=DEFAULT_CONFIG, help="Fichier de configuration .ini")
+    parser.add_argument("-r", "--rules", help="Liste de règles à exécuter (séparées par des virgules)")
+    parser.add_argument("-i", "--ips", type=Path, help="Fichier contenant les IPs cibles")
+    parser.add_argument("-o", "--output", type=Path, help="Chemin du rapport CSV")
+    parser.add_argument("-w", "--workers", type=int, help="Nombre de threads parallèles")
+
+    parser.add_argument("--snmp-user", default=os.environ.get("SNMP_USER"))
+    parser.add_argument("--snmp-auth-key", default=os.environ.get("SNMP_AUTH_KEY"))
+    parser.add_argument("--snmp-priv-key", default=os.environ.get("SNMP_PRIV_KEY"))
+    parser.add_argument("--snmp-auth-proto", default=os.environ.get("SNMP_AUTH_PROTO"))
+    parser.add_argument("--snmp-priv-proto", default=os.environ.get("SNMP_PRIV_PROTO"))
 
     args = parser.parse_args()
 
-    if not args.password:
-        args.password = getpass.getpass("SSH Password: ")
+    config = load_main_config(args.config)
+    log_level = config.get("log_level", "INFO")
+    configure_logging(log_level)
 
-    ips = load_ips(args.ips)
+    workers = args.workers or int(config.get("workers", 50))
+    ips_file = args.ips or Path(config.get("ips_file", "config/ips.txt"))
+    output_path = args.output
+    if output_path is None:
+        default_dir = config.get("output_dir", "results")
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        output_path = Path(default_dir) / f"audit_{timestamp}.csv"
+
+    if not args.password:
+        args.password = getpass.getpass("Mot de passe SSH : ")
+
+    ips = load_ips(ips_file)
     if not ips:
-        print("No IPs to audit. Exiting.")
+        logging.warning("Aucune IP à auditer - arrêt")
         return
 
+    active_rules = args.rules.split(",") if args.rules else config.get("active_rules")
+    if isinstance(active_rules, str):
+        active_rules = [rule.strip() for rule in active_rules.split(",") if rule.strip()]
+
+    if not active_rules:
+        active_rules = list(RULE_REGISTRY.keys())
+
+    unknown_rules = [rule for rule in active_rules if rule not in RULE_REGISTRY]
+    if unknown_rules:
+        raise ValueError(f"Règles inconnues demandées: {', '.join(unknown_rules)}")
+
+    rule_instances = instantiate_rules(active_rules, Path("config"))
+
     snmp_creds = {}
-    snmp_rule_active = False
-    if args.rules:
-        if "snmp_v3_check" in args.rules.split(','):
-            snmp_rule_active = True
-    elif ALL_RULES.get("snmp_v3_check"):
-        snmp_rule_active = True
+    if any(rule.name == "snmp_v3_check" for rule in rule_instances):
+        snmp_creds = {
+            "snmp_user": args.snmp_user or config.get("snmp_user"),
+            "snmp_auth_key": args.snmp_auth_key or config.get("snmp_auth_key"),
+            "snmp_priv_key": args.snmp_priv_key or config.get("snmp_priv_key"),
+            "snmp_auth_proto": (args.snmp_auth_proto or config.get("snmp_auth_proto", "SHA")).upper(),
+            "snmp_priv_proto": (args.snmp_priv_proto or config.get("snmp_priv_proto", "AES")).upper(),
+        }
+        missing = [key for key, value in snmp_creds.items() if key in {"snmp_user", "snmp_auth_key", "snmp_priv_key"} and not value]
+        if missing:
+            logging.warning("Identifiants SNMP incomplets : %s", ", ".join(missing))
 
-    if snmp_rule_active:
-        print("\n--- SNMPv3 Configuration for 'snmp_v3_check' rule ---")
-        prompt_snmp_user = args.snmp_user
-        prompt_snmp_auth_key = args.snmp_auth_key
-        prompt_snmp_priv_key = args.snmp_priv_key
+    logging.info(
+        "Démarrage audit: %s règles | %s équipements | %s threads",
+        ",".join(rule.name for rule in rule_instances),
+        len(ips),
+        workers,
+    )
 
-        if not prompt_snmp_user:
-            prompt_snmp_user = input("Enter SNMPv3 Username: ")
-        if not prompt_snmp_auth_key:
-            prompt_snmp_auth_key = getpass.getpass("Enter SNMPv3 Auth Key: ")
-        if not prompt_snmp_priv_key:
-            prompt_snmp_priv_key = getpass.getpass("Enter SNMPv3 Priv Key: ")
-
-        if all([prompt_snmp_user, prompt_snmp_auth_key, prompt_snmp_priv_key]):
-            snmp_creds = {
-                "snmp_user": prompt_snmp_user,
-                "snmp_auth_key": prompt_snmp_auth_key,
-                "snmp_priv_key": prompt_snmp_priv_key,
-                "snmp_auth_proto": args.snmp_auth_proto.upper(),
-                "snmp_priv_proto": args.snmp_priv_proto.upper()
-            }
-            print(f"Using SNMP Auth Protocol: {snmp_creds['snmp_auth_proto']}")
-            print(f"Using SNMP Priv Protocol: {snmp_creds['snmp_priv_proto']}")
-        else:
-            print("Warning: Incomplete SNMPv3 credentials provided. 'snmp_v3_check' rule will likely fail or report as non-compliant.")
-            snmp_creds = {}
-
-    rules_to_run_instances = []
-    if args.rules:
-        requested_rule_names = [r.strip() for r in args.rules.split(",")]
-        unknown = set(requested_rule_names) - set(ALL_RULES.keys())
-        if unknown:
-            parser.error(f"Unknown rules: {','.join(unknown)}")
-        rules_to_run_instances = [ALL_RULES[name] for name in requested_rule_names]
-    else:
-        rules_to_run_instances = list(ALL_RULES.values())
+    output_path.parent.mkdir(parents=True, exist_ok=True)
 
     fieldnames = ["ip", "duration", "hostname", "model", "firmware"]
-    for rule_obj in rules_to_run_instances:
-        fieldnames += [f"{rule_obj.name}_compliant", f"{rule_obj.name}_details"]
+    for rule in rule_instances:
+        fieldnames += [f"{rule.name}_compliant", f"{rule.name}_details"]
 
-    if args.output:
-        csv_file = args.output
-    else:
-        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-        csv_file = f"results/audit_{ts}.csv"
-    output_dir = os.path.dirname(csv_file)
-    if output_dir and not os.path.exists(output_dir):
-        os.makedirs(output_dir)
-
-    print(f"\n=== Parallel Audit (rules: {'all' if not args.rules else args.rules}, {args.workers} workers) ===\n")
     rows = []
-    with ThreadPoolExecutor(max_workers=args.workers) as executor:
+    with ThreadPoolExecutor(max_workers=workers) as executor:
         futures = {
-            executor.submit(run_audit, ip, args.username, args.password, rules_to_run_instances, snmp_creds): ip
+            executor.submit(run_audit, ip, args.username, args.password, rule_instances, snmp_creds): ip
             for ip in ips
         }
-        for i, f in enumerate(as_completed(futures)):
-            ip_processed = futures[f]
+        for idx, future in enumerate(as_completed(futures), start=1):
+            ip_address = futures[future]
             try:
-                result_row = f.result()
-                rows.append(result_row)
-                print(f"Processed ({i+1}/{len(ips)}): {ip_processed} - Host: {result_row.get('hostname', 'N/A')}")
-            except Exception as exc:
-                print(f"ERROR during processing of {ip_processed}: {exc}")
-                error_row = {"ip": ip_processed, "duration": 0, "hostname": "ERROR", "model": str(exc), "firmware": ""}
-                for rule_obj in rules_to_run_instances:
-                    error_row[f"{rule_obj.name}_compliant"] = False
-                    error_row[f"{rule_obj.name}_details"] = "IP Processing Error"
+                row = future.result()
+                rows.append(row)
+                logging.info("[%s/%s] %s - %s", idx, len(ips), ip_address, row.get("hostname", "N/A"))
+            except Exception as exc:  # pragma: no cover - robuste face aux erreurs runtime
+                logging.exception("Erreur pendant le traitement de %s", ip_address)
+                error_row = {"ip": ip_address, "duration": 0, "hostname": "ERROR", "model": str(exc), "firmware": ""}
+                for rule in rule_instances:
+                    error_row[f"{rule.name}_compliant"] = False
+                    error_row[f"{rule.name}_details"] = "Erreur d'exécution"
                 rows.append(error_row)
 
-    try:
-        with open(csv_file, "w", newline="", encoding="utf-8") as f:
-            writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction='ignore')
-            writer.writeheader()
-            for row in rows:
-                writer.writerow({key: str(value) for key, value in row.items()})
-        print(f"\n📄 CSV report written to {csv_file}")
+    with output_path.open("w", newline="", encoding="utf-8") as csv_handle:
+        writer = csv.DictWriter(csv_handle, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({key: str(value) for key, value in row.items()})
 
-        html_output = csv_file.replace(".csv", ".html")
-        generate_html_dashboard(csv_file, html_output)
-        print(f"📄 HTML report written to {html_output}")
+    logging.info("Rapport CSV: %s", output_path)
+    html_output = output_path.with_suffix(".html")
+    generate_html_dashboard(str(output_path), str(html_output))
+    logging.info("Rapport HTML: %s", html_output)
 
-    except IOError as e:
-        print(f"Error writing CSV/HTML file: {e}")
-    except Exception as e:
-        print(f"An unexpected error occurred during report generation: {e}")
 
 if __name__ == "__main__":
     main()

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,68 @@
+"""Tests unitaires des fonctions de parsing."""
+
+from __future__ import annotations
+
+import unittest
+
+from audit.rules.cpu_usage import parse_cpu_output
+from audit.rules.fan_health import analyse_fans
+from audit.rules.memory_usage import extract_usage_percent
+from audit.rules.power_supply import analyse_power
+from audit.rules.storage_capacity import extract_disk_usage, extract_firmwares
+from audit.rules.temperature import parse_temperatures
+from audit.rules.transceiver_diagnostics import parse_transceivers
+from audit.rules.uptime import parse_uptime
+
+
+class ParserTests(unittest.TestCase):
+    def test_cpu_parse_generic(self) -> None:
+        output = "Five seconds: 23% One minute: 12% Five minutes: 5%"
+        values, labels = parse_cpu_output(output)
+        self.assertEqual(values, [23.0, 12.0, 5.0])
+        self.assertEqual(labels, ["5s", "1m", "5m"])
+
+    def test_memory_percent(self) -> None:
+        self.assertEqual(extract_usage_percent("Memory usage: 83%"), 83.0)
+        self.assertIsNone(extract_usage_percent("No percent here"))
+
+    def test_fan_analysis(self) -> None:
+        ok, total = analyse_fans("Fan1 Normal\nFan2 Faulty")
+        self.assertEqual((ok, total), (1, 2))
+
+    def test_power_analysis(self) -> None:
+        ok, fault, absent, total = analyse_power("Power 1 : OK\nPower 2 : Fault\nPower 3 : Absent")
+        self.assertEqual((ok, fault, absent, total), (1, 1, 1, 3))
+
+    def test_storage_parsers(self) -> None:
+        disk_output = "524288 KB total (173956 KB free)"
+        self.assertEqual(extract_disk_usage(disk_output), (524288, 173956))
+        fw_output = "-rw-    174,624,256  some-image.bin"
+        self.assertEqual(extract_firmwares(fw_output), [("some-image.bin", 174624256)])
+
+    def test_temperature_table(self) -> None:
+        output = "Temp: 35 C, Warning: 65 C, Alarm: 75 C"
+        temps, lower, warn, alarm = parse_temperatures(output)
+        self.assertEqual(temps[0], 35.0)
+        self.assertEqual((lower, warn, alarm), (None, 65.0, 75.0))
+
+    def test_transceiver_parse(self) -> None:
+        output = (
+            "GigabitEthernet1/0/1 transceiver diagnostic information:\n"
+            "  Temperature : 35 Threshold : -5 to 85\n"
+            "  Voltage : 3.3 Threshold : 3.0 to 3.6\n"
+        )
+        parsed = parse_transceivers(output)
+        self.assertEqual(len(parsed), 1)
+        self.assertTrue(parsed[0]["present"])
+        self.assertEqual(len(parsed[0]["measurements"]), 2)
+
+    def test_uptime_parser(self) -> None:
+        output = "Uptime is 1 weeks, 2 days, 3 hours, 4 minutes\nLast reboot reason : power-off"
+        formatted, reason, seconds = parse_uptime(output)
+        self.assertEqual(reason, "power-off")
+        self.assertEqual(seconds, 1 * 7 * 86400 + 2 * 86400 + 3 * 3600 + 4 * 60)
+        self.assertIn("weeks", formatted)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- replace the main orchestrator with a configurable runner that loads rules and credentials from INI files and adds structured logging
- port the pending audit scripts into modular rule classes with shared helpers and central configuration per rule
- document the workflow for adding audits and cover the parsing helpers with unit tests

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68d393f22dcc8332b978507dd3a7fd8e